### PR TITLE
Update the url of the package index at micropython.org

### DIFF
--- a/micropip/micropip.py
+++ b/micropip/micropip.py
@@ -171,7 +171,7 @@ def url_open(url):
 # Now searches official library first before looking on PyPi for user packages
 def get_pkg_metadata(name):
     try:
-        f = url_open("https://micropython.org/resources/upi/%s/json" % name)
+        f = url_open("https://micropython.org/pi/%s/json" % name)
     except:
         f = url_open("https://pypi.org/pypi/%s/json" % name)
     s = read_lines(f)


### PR DESCRIPTION
It looks like `https://micropython.org/resources/upi/%s/json` doesn't work anymore and `https://micropython.org/pi/%s/json` should be used instead (this is given by `upip.index_urls` the latest stable Unix Micropython).